### PR TITLE
feat: Allow definition of the same config key multiple times using a suffix

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -18,6 +18,8 @@ web_servers:
     projects-aws:
       HostName: projects-aws.example.com
       IdentityFile: ~/.ssh/aws
+      LocalForward-1: 8080 127.0.0.1:80
+      LocalForward-2: 8443 127.0.0.1:443
 
 raspberry_pis:
   Config:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='sshush',
-      version='1.4.0',
+      version='1.5.0',
       description='SSH Config management tool',
       url='http://github.com/bencromwell/sshush',
       author='Ben Cromwell',

--- a/sshush/sshush.py
+++ b/sshush/sshush.py
@@ -1,3 +1,4 @@
+import re
 import yaml
 from collections import OrderedDict
 
@@ -21,10 +22,7 @@ def ordered_load(stream, loader=yaml.Loader, object_pairs_hook=OrderedDict):
 
 def read_file(file):
     with open(file, 'r') as stream:
-        # try:
-            return ordered_load(stream, yaml.SafeLoader)
-        # except yaml.YAMLError as e:
-        #     print(e)
+        return ordered_load(stream, yaml.SafeLoader)
 
 
 class Parser:
@@ -89,6 +87,9 @@ class Parser:
                 host_settings = {**settings, **host_details}
 
                 for k, v in host_settings.items():
+                    suffix = re.search(r'-\d+$', k)
+                    if suffix:
+                        k = k.rstrip(suffix.group()) 
                     output.append('    {} {}'.format(k, v))
 
                 output.append("")
@@ -100,6 +101,9 @@ class Parser:
         if self.global_values is not None:
             output.append('Host *')
             for key, value in self.global_values.items():
+                suffix = re.search(r'-\d+$', key)
+                if suffix:
+                    key = key.rstrip(suffix.group()) 
                 output.append('    {} {}'.format(key, value))
 
         return "\n".join(output)


### PR DESCRIPTION
I need to redefine a key multiple times and it's incompatible with the YAML format. I added this feature that strips the suffix `-[0-9]` if provided. 

Example: 
```yaml
remote:
  Hosts:
    bastion:
      HostName: 1.2.3.4
      LocalForward-1: 8080 127.0.0.1:80
      LocalForward-2: 8443 127.0.0.1:443
```
Would output
```ssh-config
Host bastion
    HostName 1.2.3.4
    LocalForward 8080 127.0.0.1:80
    LocalForward 8443 127.0.0.1:443
```