### PR TITLE
feat: alias for path arg

### DIFF
--- a/sshush/command_line.py
+++ b/sshush/command_line.py
@@ -27,7 +27,7 @@ def main():
     )
 
     arg_parser.add_argument(
-        '--path', '-p',
+        '--path', '-p', '-o', '--output',
         help='Path to SSH config file if it differs from {}'.format(default_path),
         default=default_path
     )


### PR DESCRIPTION
-p / --path is a bit ambiguous. I find myself thinking it should be -o / --output. 

Adds the option. May consider deprecating -p in a 2.0.0 release.